### PR TITLE
Fix missing ZeroMQ include directory

### DIFF
--- a/Readout/CMakeLists.txt
+++ b/Readout/CMakeLists.txt
@@ -84,7 +84,12 @@ set(SRCS
 )
 
 include_directories(
-        ${CMAKE_CURRENT_SOURCE_DIR}/../RORC/include ${Boost_INCLUDE_DIRS} ${Monitoring_INCLUDE_DIRS}  ${FAIRROOT_INCLUDE_DIR} ${FAIRROOT_INCLUDE_DIR}/fairmq
+        ${CMAKE_CURRENT_SOURCE_DIR}/../RORC/include
+        ${Boost_INCLUDE_DIRS}
+        ${Monitoring_INCLUDE_DIRS}
+        ${FAIRROOT_INCLUDE_DIR}
+        ${FAIRROOT_INCLUDE_DIR}/fairmq
+        ${ZeroMQ_INCLUDE_DIR}
 )
 
 add_library(


### PR DESCRIPTION
This fix makes it work also with own-built ZeroMQ (which is the case on central machines).